### PR TITLE
fix call to showwarning in generateCoefficients.py

### DIFF
--- a/bin.src/generateCoefficients.py
+++ b/bin.src/generateCoefficients.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
                                          % (subsetOrbits.orbits.objId.iloc[0],
                                             subsetOrbits.orbits.objId.iloc[-1],
                                             n, n + nObj, t, t + tSpan, ve.message),
-                                         UserWarning, log)
+                                         UserWarning, "generateCoefficients.py", 132, file=log)
 
             # Put this in a separate try/except block, because errors here can mask errors in the previous
             # length determination stage otherwise.
@@ -152,7 +152,7 @@ if __name__ == '__main__':
                                              % (subsetOrbits.orbits.objId.iloc[0],
                                                 subsetOrbits.orbits.objId.iloc[-1],
                                                 n, n + nObj, t, t + tSpan, ve.message),
-                                             UserWarning, log)
+                                             UserWarning, "generateCoefficients.py", 147, file=log)
 
             # Write out coefficients.
             cheb.write(coeffFile, residFile, failedFile, append=append)


### PR DESCRIPTION
playing around with showwarning in other python scrips,
the filename argument is supposed to be the name of the
source code file raising the warning.  The lineno argument
is required and represents the line number in the source
code that is raising the warning.  The file kwarg is the
file handle to which the warning is written.