### PR TITLE
Skipping unit tests that depend on numexpr, for jenkins.

### DIFF
--- a/tests/testChebyFits.py
+++ b/tests/testChebyFits.py
@@ -8,6 +8,14 @@ from lsst.sims.movingObjects import ChebyFits
 from lsst.utils import getPackageDir
 
 
+try:
+    import numexpr
+    _has_numexpr = True
+except ImportError:
+    _has_numexpr = False
+
+
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestChebyFits(unittest.TestCase):
     def setUp(self):
         self.testdir = os.path.join(getPackageDir('sims_movingObjects'), 'tests/orbits_testdata')
@@ -103,6 +111,7 @@ class TestChebyFits(unittest.TestCase):
         self.assertTrue(os.path.isfile('tmpResids'))
 
 
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestRun(unittest.TestCase):
     def setUp(self):
         self.testdir = os.path.join(getPackageDir('sims_movingObjects'), 'tests/orbits_testdata')

--- a/tests/testChebyValues.py
+++ b/tests/testChebyValues.py
@@ -12,6 +12,14 @@ from lsst.sims.movingObjects import ChebyValues
 from lsst.utils import getPackageDir
 
 
+try:
+    import numexpr
+    _has_numexpr = True
+except ImportError:
+    _has_numexpr = False
+
+
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestChebyValues(unittest.TestCase):
     def setUp(self):
         self.testdatadir = os.path.join(getPackageDir('sims_movingObjects'), 'tests/orbits_testdata')
@@ -103,6 +111,7 @@ class TestChebyValues(unittest.TestCase):
         self.assertEqual(len(ephemerides['ra']), 3)
 
 
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestJPLValues(unittest.TestCase):
     # Test the interpolation-generated RA/Dec values against JPL generated RA/Dec values.
     # The resulting errors should be similar to the errors reported

--- a/tests/testEphemerides.py
+++ b/tests/testEphemerides.py
@@ -10,6 +10,14 @@ from lsst.sims.movingObjects import PyOrbEphemerides
 from lsst.utils import getPackageDir
 
 
+try:
+    import numexpr
+    _has_numexpr = True
+except ImportError:
+    _has_numexpr = False
+
+
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestPyOrbEphemerides(unittest.TestCase):
     def setUp(self):
         self.testdir = os.path.join(getPackageDir('sims_movingObjects'), 'tests/orbits_testdata')
@@ -114,6 +122,7 @@ class TestPyOrbEphemerides(unittest.TestCase):
             np.testing.assert_allclose(ephsAllKEP[column], ephsAll[column], rtol=0, atol=1e-7)
 
 
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestJPLValues(unittest.TestCase):
     """Test the oorb generated RA/Dec values against JPL generated RA/Dec values."""
     def setUp(self):

--- a/tests/testOrbits.py
+++ b/tests/testOrbits.py
@@ -7,6 +7,14 @@ from lsst.sims.movingObjects import Orbits
 from lsst.utils import getPackageDir
 
 
+try:
+    import numexpr
+    _has_numexpr = True
+except ImportError:
+    _has_numexpr = False
+
+
+@unittest.skipIf(not _has_numexpr, "No numexpr available.")
 class TestOrbits(unittest.TestCase):
     def setUp(self):
         self.testdir = os.path.join(getPackageDir('sims_movingObjects'), 'tests/orbits_testdata')


### PR DESCRIPTION
Just add @unittest.skipIf there is no numexpr on the system. 